### PR TITLE
[enh] Add table of content 'includes'

### DIFF
--- a/_js/app.js
+++ b/_js/app.js
@@ -211,6 +211,17 @@ $(document).ready(function () {
             }
             $("#wrapper").show();
 
+            // Load table of contents
+            var tableofcontents = $(".tableofcontent");
+            $.each(tableofcontents, function(i, toc){
+                var href = '_pages/'+toc.getAttribute("href")+'.md';
+                var activeid = parseInt(toc.getAttribute("step"))-1;
+                $(toc).load(href, function() {
+                    var activeitem = $($(toc).find(".tableofcontent_items li")[activeid]);
+                    activeitem.css("font-weight", "bold");
+                });
+            });
+
         });
     }
 


### PR DESCRIPTION
Related to https://github.com/YunoHost/doc/pull/554 , and more generally related to the documentation organization. In many case we'd like to be able to have 'table of contents' for guides so that people can have the big picture of the process they're in.

Typically the full 'Get started with YunoHost' should include : 

- some explanations regardining what's self-hosting, why and why not self-host youself
- discussion about which installation support to use
- the actual install / postinstall
- post-postinstall stuff like domain names, ports forwarding, certificate, discovering the basic features of YunoHost
- ...

With this PR, one can add in a page a block like : 

```html
<div class="tableofcontent" href="./superguide_fr" step="1"></div>
```

And `superguide_fr` may contain : 

```
<div class="row">
<div class="col-sm-8 col-sm-offset-2">
<div class="panel panel-primary">
<div class="panel-heading">
    <h3 class="panel-title">Super guide de ouf</h3>
</div>
<div class="panel-body">
    <ol class="tableofcontent_items">
        <li><a href="/page1">Etape 1</a></li>
        <li><a href="/page2">Etape 2</a></li>
        <li><a href="/page3">Etape 3</a></li>
        <li><a href="/page4">Etape 4</a></li>
    </ol>
</div></div></div></div>
```

Demo is available here : https://mjollnir.netlib.re/simone/#/testtoc_fr