### PR TITLE
Automatically fallback to english if requested page ain't available in user's language

### DIFF
--- a/_js/app.js
+++ b/_js/app.js
@@ -181,14 +181,14 @@ $(document).ready(function () {
     }
 
     function loadMD(c, data) {
-	if (data.indexOf("NO_MARKDOWN_PARSING") !== -1)
+        if (data.indexOf("NO_MARKDOWN_PARSING") !== -1)
         {
-	    html = data;
+            html = data;
         }
-	else
-	{
+        else
+        {
             html = marked(data);
-	}
+        }
         $('#form textarea').val(data);
         $('#content').html('');
         c.swap(html, function() {
@@ -209,7 +209,7 @@ $(document).ready(function () {
                 }
             });
 
-	    $(".javascriptDisclaimer").hide();
+            $(".javascriptDisclaimer").hide();
 
             // Scroll to anchor
             if (typeof anchor !== 'undefined' && $('#'+ anchor).length > 0) {

--- a/_js/app.js
+++ b/_js/app.js
@@ -25,43 +25,91 @@ $(document).ready(function () {
     var app = Sammy('#content', function(sam) {
 
         sam.helpers({
-            view: function (page) {
+            view: function (page_wanted) {
                 var c = this;
-                anchor = page.split('#')[1];
-                page = page.split('#')[0];
+
+                // (I don't understand what this does / why it's here ...)
                 absolutePage = location.href.split('#/')[0].split('/').pop();
                 if (absolutePage !== "" && absolutePage !== page) {
                     c.redirect('/#/'+ absolutePage);
                 }
-                if (page.substr(page.length - 3, 1) != '_') {
-                    currentLang = store.get('lang');
-                    if (currentLang != conf.defaultLanguage) {
-                        page = page +'_'+ currentLang;
-                    }
-                } else if (page.substr(page.length - 2) == conf.defaultLanguage) {
-                    // Indicate page specifically
-                    page = page.substr(0, page.length - 3);
-                }
-                store.set('page', page);
 
-                var d = store.get('data-'+ page);
+                // Let's distinguish :
+                // - the page_wanted by the user, for example a: foo or b: foo_en or c: foo_it
+                // - the basepage : for all a, b, c, it's "foo"
+                // - the md filename to be fetch : for a: foo(.md), b: foo(.md), c: foo_it(.md)
+
+                anchor = page_wanted.split('#')[1];
+                page_wanted = page_wanted.split('#')[0];
+
+                // - appendLang depends on user's language
+                // (taken from browser header or set explicitly through small language selector in bottom left)
+                // english -> appendLang equals empty string
+                // italian -> appendLang equals "_it"
+                var appendLang = '';
+                if (store.get('lang') != conf.defaultLanguage) {
+                     appendLang = '_'+ store.get('lang');
+                }
+
+                // Case a: page_wanted is foo (implicit language)
+                if (page_wanted.substr(page_wanted.length - 3, 1) != '_') {
+                    basepage = page_wanted;
+                    mdfile = basepage + appendLang;
+                    implicitLanguage = true;
+                // Case b: page_wanted is foo_en (explicit default language)
+                } else if (page_wanted.substr(page_wanted.length - 2) == conf.defaultLanguage) {
+                    basepage = page_wanted.substr(0, page_wanted.length - 3);
+                    mdfile = basepage;
+                    implicitLanguage = false;
+                // Case c: page_wanted is foo_it (explicit language)
+                } else {
+                    basepage = page_wanted.substr(0, page_wanted.length - 3);
+                    mdfile = page_wanted;
+                    implicitLanguage = false;
+                }
+
+                store.set('page', page_wanted);
+
+                // If this page was already saved (this happens when edited in-browser?), recover data and load them
+                var d = store.get('data-'+ page_wanted);
                 if (d !== null) {
                    loadMD(c, d);
-                } else {
-                    $("#wrapper").fadeOut(150, function() {
-                        $.get('_pages/'+ page +'.md', function(data) {
-                            loadMD(c, data);
-                        }).fail(function() {
-                            var append = '';
-                            if (store.get('lang') != conf.defaultLanguage) {
-                                 append = '_'+ store.get('lang');
-                            }
-                            $.get('_pages/default'+ append +'.md', function(data) {
+                   return;
+                }
+
+                // Otherwise, try to fetch the md file
+                $("#wrapper").fadeOut(150, function() {
+                    $.get('_pages/'+ mdfile +'.md', function(data) {
+                        loadMD(c, data);
+                    // But maybe the mdfile doesn't exist....
+                    }).fail(function() {
+
+                        // If the user requested the page with implicit language
+                        // and we didnt already try english
+                        if ((implicitLanguage) && (appendLang)) {
+                            // We try to fallback to english
+                            $.get('_pages/'+ basepage +'.md', function(data) {
+
+                                fallback_disclaimer = '<div class="alert alert-warning" markdown="1" style="margin-right: 120px; margin-top: 12px">' + i18n[store.get('lang')]["fallback_to_english"] + "</div>\n\n"
+                                url_to_start_translation = location.href.split("#/")[0] + "#/" + page_wanted + appendLang;
+                                fallback_disclaimer = fallback_disclaimer.replace("{url_to_start_translation}", url_to_start_translation);
+                                data = fallback_disclaimer + data;
+                                loadMD(c, data);
+                            }).fail(function() {
+                                // English page still doesn't exist...
+                                $.get('_pages/default'+ appendLang +'.md', function(data) {
+                                    loadMD(c, data);
+                                });
+                            })
+                        }
+                        // Otherwise, show the default "new page" thing
+                        else {
+                            $.get('_pages/default'+ appendLang +'.md', function(data) {
                                 loadMD(c, data);
                             });
-                        });
+                       }
                     });
-                }
+                });
             },
             viewPage: function(page) {
                 var c = this;

--- a/_pages/default.md
+++ b/_pages/default.md
@@ -2,10 +2,13 @@
 
 This page is not created yet, you can edit it by pressing ```<ESC>``` on your keyboard or by clicking the "edit" button on the bottom-right side of your screen. You will be able to preview your changes by pressing ```<ESC>``` again or by clicking the "preview" button.
 
-** Note: ** You will need to provide an email adress to validate your submission.
+If you are translating another page, a good starting point might be the markdown code from the original page, which you can obtain by pressing ```<ESC>``` on the original page.
+
+** Note: ** You will need to provide an email address to validate your submission.
 
 ###Syntax
 
 This page use the markdown syntax, please refer to the documentation for further informations:
 
 http://daringfireball.net/projects/markdown/syntax
+

--- a/_pages/default_fr.md
+++ b/_pages/default_fr.md
@@ -2,6 +2,8 @@
 
 Cette page n’existe pas encore, vous pouvez l’éditer en appuyant sur la touche ```<Échap>``` de votre clavier, ou en cliquant sur le bouton "Éditer" en bas à droite de votre écran. Vous pourrez avoir un aperçu de vos changements en appuyant à nouveau sur la touche ```<Échap>``` ou en cliquant sur le bouton "Aperçu".
 
+Si vous commencer la traduction d'une autre page, un bon point de départ est probablement de récupérer le code markdown de la page originale, que vous pouvez obtenir également en appuyant sur ```<Échap>``` sur la page originale.
+
 ** Note : ** Vous aurez besoin d'une adresse email pour valider votre proposition.
 
 

--- a/i18n.json
+++ b/i18n.json
@@ -27,7 +27,8 @@
         "support": "Support",
         "whyEmail": "To allow us to fight abuses, you will be asked to confirm your submission by email. We won't make your email public and won't use it for anything else!",
         "tellUsWhatYouDid": "Tell us what you did there!",
-        "considerUsingGithub": "ProTip™ : if you plan to contribute often to the documentation, consider using Git/Github directly!"
+        "considerUsingGithub": "ProTip™ : if you plan to contribute often to the documentation, consider using Git/Github directly!",
+        "fallback_to_english": "The page requested is not yet available in your favourite language. Instead, here is the english version. If you wish to start translating this page, please go to [this page]({url_to_start_translation})."
     },
     "fr": {
         "edit": "Éditer",
@@ -57,8 +58,8 @@
         "support": "Support",
         "whyEmail": "Pour nous permettre de combattre les abus, nous vous demanderons de confirmer votre proposition de changement par email. Nous ne renderons pas cette adresse publique et ne l'utiliserons pas à d'autres fins !",
         "tellUsWhatYouDid": "Dites-nous ce que vous avez changé !",
-        "considerUsingGithub": "ProTip™ : si vous prévoyez de contribuer souvent à la documentation, nous vous recommendons d'utiliser Git/Github directement !"
-
+        "considerUsingGithub": "ProTip™ : si vous prévoyez de contribuer souvent à la documentation, nous vous recommendons d'utiliser Git/Github directement !",
+        "fallback_to_english": "La page demandée n'est pour le moment pas disponible en français. Voici à la place la version en anglais. Si vous souhaitez commencer une traduction de cette page, vous pouvez vous rendre sur [cette page]({url_to_start_translation})."
     },
     "ar": {
         "edit": "تعديل",


### PR DESCRIPTION
So far, turns out that if you attempted to visit `/somepage` as a non-english user, chances are you would see some "New page" / empty page stuff because the code was dumb. This may not had a huge impact on english and french user, but that was probably a disaster for German / Italian / ... for whom only a handful of pages are available in their languages.

Anyway, here I reworked the JS so that, if the page doesn't exist when requested with implicit language (`/somepage` vs `/somepage_it`) it will try to fetch and display the english version instead, with a small disclaimer at the top explaining the situation.

To test this, you can try to visit [this page](https://yunohost.org/#/groups_and_permissions) with a) Your browser set to English by default, and b) Your browser set to French by default. Before this fix, if your browser is in french, you would get a new page / empty page being shown.

Note that you may still ask the page explicitly in french or english by appending `_fr` or `_en` at the end.